### PR TITLE
Add native bindings to install unity to default location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ plugins {
     id 'com.jfrog.bintray' version '1.8.4'
     id 'nebula.release' version '6.3.5'
     id 'jacoco'
+    id 'com.github.kt3k.coveralls' version '2.8.2'
 }
 
 group "net.wooga"
@@ -92,6 +93,13 @@ publishing {
         Bintray(MavenPublication) {
             from components.java
         }
+    }
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true
+        html.enabled = true
     }
 }
 

--- a/src/main/java/net/wooga/uvm/Component.java
+++ b/src/main/java/net/wooga/uvm/Component.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 Wooga GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/wooga/uvm/Installation.java
+++ b/src/main/java/net/wooga/uvm/Installation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 Wooga GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/wooga/uvm/UnityVersionManager.java
+++ b/src/main/java/net/wooga/uvm/UnityVersionManager.java
@@ -79,6 +79,30 @@ public class UnityVersionManager {
     public static native Installation installUnityEditor(String version, File destination);
 
     /**
+     * Installs the given version of unity to default destination.
+     *
+     * If the unity version is already installed, returns early.
+     *
+     * @param version the version of unity to install
+     * @return a {@code Installation} object or null
+     */
+    public static native Installation installUnityEditor(String version);
+
+    /**
+     * Installs the given version of unity and additional components to default destination.
+     *
+     * If the unity version and all requested components are already installed, returns early.
+     *
+     * @param version the version of unity to install
+     * @param components a list of optional {@code Component}s to install
+     *
+     * @return a {@code Installation} object or null
+     * @see Component
+     * @see Installation
+     */
+    public static native Installation installUnityEditor(String version, Component[] components);
+
+    /**
      * Installs the given version of unity and additional components to destination.
      *
      * If the unity version and all requested components are already installed, returns early.

--- a/src/test/groovy/net/wooga/uvm/InstallationSpec.groovy
+++ b/src/test/groovy/net/wooga/uvm/InstallationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 Wooga GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/net/wooga/uvm/UnityVersionManagerSpec.groovy
+++ b/src/test/groovy/net/wooga/uvm/UnityVersionManagerSpec.groovy
@@ -17,6 +17,8 @@
 
 package net.wooga.uvm
 
+import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -169,6 +171,7 @@ class UnityVersionManagerSpec extends Specification {
         destination.deleteDir()
     }
 
+    @IgnoreIf({env.containsKey("CI")})
     def "installUnityEditor installs unity to default location"() {
         given: "a version to install"
         def version = "2017.1.0f1"
@@ -219,7 +222,10 @@ class UnityVersionManagerSpec extends Specification {
         destination.deleteDir()
     }
 
+    @IgnoreIf({env.containsKey("CI")})
     def "installUnityEditor installs unity and components to default location"() {
+
+
         given: "a version to install"
         def version = "2017.1.0f1"
         assert !UnityVersionManager.listInstallations().collect({ it.version }).contains(version)

--- a/src/test/groovy/net/wooga/uvm/UnityVersionManagerSpec.groovy
+++ b/src/test/groovy/net/wooga/uvm/UnityVersionManagerSpec.groovy
@@ -50,7 +50,15 @@ class UnityVersionManagerSpec extends Specification {
 
     def "can call :installUnityEditor on UnityVersionManager"() {
         when:
-        UnityVersionManager.installUnityEditor(null, null)
+        UnityVersionManager.installUnityEditor("")
+        then:
+        noExceptionThrown()
+        when:
+        UnityVersionManager.installUnityEditor("", new File(""))
+        then:
+        noExceptionThrown()
+        when:
+        UnityVersionManager.installUnityEditor("", [] as Component[])
         then:
         noExceptionThrown()
         when:
@@ -65,7 +73,7 @@ class UnityVersionManagerSpec extends Specification {
         UnityVersionManager.uvmVersion() == expectedVersion
 
         where:
-        expectedVersion = "0.0.1"
+        expectedVersion = "0.1.0"
     }
 
     File mockUnityProject(String editorVersion) {
@@ -161,6 +169,24 @@ class UnityVersionManagerSpec extends Specification {
         destination.deleteDir()
     }
 
+    def "installUnityEditor installs unity to default location"() {
+        given: "a version to install"
+        def version = "2017.1.0f1"
+        assert !UnityVersionManager.listInstallations().collect({ it.version }).contains(version)
+
+        when:
+        def result = UnityVersionManager.installUnityEditor(version)
+
+        then:
+        result != null
+        result.location.exists()
+        result.version == version
+        UnityVersionManager.listInstallations().collect({ it.version }).contains(version)
+
+        cleanup:
+        result.location.deleteDir()
+    }
+
     def "installUnityEditor installs unity and components to location"() {
         given: "a version to install"
         def version = "2017.1.0f1"
@@ -191,5 +217,27 @@ class UnityVersionManagerSpec extends Specification {
 
         cleanup:
         destination.deleteDir()
+    }
+
+    def "installUnityEditor installs unity and components to default location"() {
+        given: "a version to install"
+        def version = "2017.1.0f1"
+        assert !UnityVersionManager.listInstallations().collect({ it.version }).contains(version)
+
+        when:
+        def result = UnityVersionManager.installUnityEditor(version, [Component.android, Component.ios].toArray() as Component[])
+
+        then:
+        result != null
+        result.location.exists()
+        result.version == version
+        UnityVersionManager.listInstallations().collect({ it.version }).contains(version)
+        def playbackEngines = new File(result.location, "PlaybackEngines")
+        playbackEngines.exists()
+        new File(playbackEngines, "iOSSupport").exists()
+        new File(playbackEngines, "AndroidPlayer").exists()
+
+        cleanup:
+        result.location.deleteDir()
     }
 }


### PR DESCRIPTION
## Description

This patch adds two more method overloads to `UnityVersionManager`.

* `public static native Installation installUnityEditor(String version);`
* `public static native Installation installUnityEditor(String version, Component[] components);`

These API's compliment the additional install methods which require a `File` destination.

## Changes

![ADD] API method `Installation installUnityEditor(String version)`
![ADD] API method `Installation installUnityEditor(String version, Component[] components)`
![UPDATE] License Headers

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
