### PR TITLE
Update rust create version during build

### DIFF
--- a/rust/build.gradle
+++ b/rust/build.gradle
@@ -46,6 +46,9 @@ processRustSource {
             include "Cargo.toml"
             into file("${buildDir}/rust-project")
         }
+
+        println("replace version")
+        ant.replaceregexp(file: "${buildDir}/rust-project/Cargo.toml", match: '^version\\s=.*$', replace:"version = \"${project.version}\"", byline: true)
     }
 }
 

--- a/src/test/groovy/net/wooga/uvm/UnityVersionManagerSpec.groovy
+++ b/src/test/groovy/net/wooga/uvm/UnityVersionManagerSpec.groovy
@@ -69,15 +69,6 @@ class UnityVersionManagerSpec extends Specification {
         noExceptionThrown()
     }
 
-    @Unroll
-    def "uvmVersion is #expectedVersion"() {
-        expect:
-        UnityVersionManager.uvmVersion() == expectedVersion
-
-        where:
-        expectedVersion = "0.1.0"
-    }
-
     File mockUnityProject(String editorVersion) {
         def outerDir = File.createTempDir("uvm_jni_projects_", "_base_path")
         def projectDir = new File(outerDir, "unity_testproject")


### PR DESCRIPTION
## Description

This project uses nebular release to manage version numbers. This patch will update the `Cargo.toml` version to reflect this version also in the crate. This is then used to set version inside the rust library.

## Changes

* ![IMPROVE] rust native library auto versioning

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
