### PR TITLE
Fix windows component install when version is already installed

### DIFF
--- a/rust/src/install.rs
+++ b/rust/src/install.rs
@@ -176,7 +176,13 @@ pub fn install(
         if let Some(variants) = variants {
             for variant in variants {
                 let component: Component = variant.into();
-                let variant_destination = component.installpath();
+                //fix better
+                let variant_destination = if cfg![windows] {
+                    Some(base_dir.to_path_buf())
+                } else {
+                    component.installpath()
+                };
+
                 let installation_data = InstallObject {
                     version: version.clone(),
                     variant: component.into(),


### PR DESCRIPTION
## Description

This patch is a additional patch for https://github.com/wooga/unity-version-manager-jni/pull/3 The last patch missed the duplicate code in case we want to install a component for a already installed unity version.

## Changes

* ![FIX] windows component install when version is already installed

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"