### PR TITLE
Add readUnityVersion helper method

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-padding 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -575,7 +575,7 @@ name = "md-5"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "block-buffer 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "opaque-debug 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "uvm_core"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cluFlock 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1506,7 +1506,7 @@ dependencies = [
  "flexi_logger 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "uvm_core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uvm_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1617,7 +1617,7 @@ dependencies = [
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
-"checksum block-buffer 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47dc7795bae66723a5ee26b79eea4c398a5395dafbaaa81821730bd318ff718f"
+"checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
 "checksum block-padding 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc4358306e344bf9775d0197fd00d2603e5afb0771bb353538630f022068ea3"
 "checksum byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "980479e6fde23246dfb54d47580d66b4e99202e7579c5eaa9fe10ecb5ebd2182"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
@@ -1778,7 +1778,7 @@ dependencies = [
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dab5c5526c5caa3d106653401a267fed923e7046f35895ffcb5ca42db64942e6"
-"checksum uvm_core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fcea063b8180f8086e557bf3871a834468153123f958e0f9c9f3e6b6679f934f"
+"checksum uvm_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "194d388a344c17aee0db58a180d23f313ca46791dd2c8a8708c323420fe784e8"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -363,3 +363,22 @@ pub extern "system" fn Java_net_wooga_uvm_Installation_getComponents(
     start_logger();
     get_installation_components(&env, object).unwrap_or_else(jni_utils::print_error_and_return_null)
 }
+
+fn get_installation(env: &JNIEnv, path: JObject) -> error::UvmJniResult<jobject> {
+    let path = jni_utils::get_path(&env, path)?;
+    let installation = uvm_core::unity::Installation::new(&path)?;
+    let native_installation = jni_utils::get_installation(&env,&installation)?;
+    Ok(native_installation.into_inner())
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern "system" fn Java_net_wooga_uvm_Installation_atLocation(
+    env: JNIEnv,
+    _class: JClass,
+    path: JObject
+) -> jobject {
+    start_logger();
+    get_installation(&env, path)
+        .unwrap_or_else(jni_utils::print_error_and_return_null)
+}

--- a/src/main/java/net/wooga/uvm/Installation.java
+++ b/src/main/java/net/wooga/uvm/Installation.java
@@ -62,4 +62,12 @@ public class Installation {
     }
 
     public native Component[] getComponents();
+
+    /**
+     * Returns a @{code Installation} object from given path.
+     *
+     * @param installationLocation the path to the unity installation
+     * @return a @{code Installation} object or @{code null} if installation can't be found
+     */
+    public static native Installation atLocation(File installationLocation);
 }

--- a/src/main/java/net/wooga/uvm/UnityVersionManager.java
+++ b/src/main/java/net/wooga/uvm/UnityVersionManager.java
@@ -116,4 +116,19 @@ public class UnityVersionManager {
      * @see Installation
      */
     public static native Installation installUnityEditor(String version, File destination, Component[] components);
+
+
+    /**
+     * Return the version as {@code String} of the unity installation at the provided location or {@code Null}.
+     *
+     * @param installationLocation the path to the unity installation
+     * @return a version string or {@code null}
+     */
+    public static String readUnityVersion(File installationLocation) {
+        Installation installation = Installation.atLocation(installationLocation);
+        if(installation != null) {
+            return installation.getVersion();
+        }
+        return null;
+    }
 }

--- a/src/test/groovy/net/wooga/uvm/InstallationSpec.groovy
+++ b/src/test/groovy/net/wooga/uvm/InstallationSpec.groovy
@@ -74,4 +74,31 @@ class InstallationSpec extends Specification {
         valueMessage = components.size() > 0 ? "list of installed components" : "empty list"
     }
 
+    @Unroll("can fetch installation at location")
+    def "get a installation from a File location"() {
+        given:
+        def basedir = Files.createTempDirectory(buildDir.toPath(), "installationSpec_installation_at_location").toFile()
+        basedir.deleteOnExit()
+        def destination = new File(basedir, version)
+        assert !destination.exists()
+        def installation = UnityVersionManager.installUnityEditor(version, destination)
+        assert destination.exists()
+
+        expect:
+        def installation2 = Installation.atLocation(destination)
+        installation2 != null
+        installation2 == installation
+        !installation2.is(installation)
+
+        cleanup:
+        destination.deleteDir()
+
+        where:
+        version = "2017.1.0f1"
+    }
+
+    def "return null when installation at location doesn't exist"() {
+        expect:
+        !Installation.atLocation(File.createTempDir())
+    }
 }

--- a/src/test/groovy/net/wooga/uvm/UnityVersionManagerSpec.groovy
+++ b/src/test/groovy/net/wooga/uvm/UnityVersionManagerSpec.groovy
@@ -262,4 +262,16 @@ class UnityVersionManagerSpec extends Specification {
         cleanup:
         result.location.deleteDir()
     }
+
+    def "returns unity version at location"() {
+        given: "a installation"
+        def installation = UnityVersionManager.listInstallations().first()
+        assert installation
+
+        when:
+        def result = UnityVersionManager.readUnityVersion(installation.location)
+
+        then:
+        result == installation.version
+    }
 }


### PR DESCRIPTION
## Description

This patch adds a new static helper method to `UnityVersionManager`
class:

```java
public static String readUnityVersion(File);
```

It returns the version of unity at the specified path or `null`.

This new helper method uses a static native method in `Installation`

```java
public static native Installation atLocation(File);
```

This method allows to fetch an `Installation` from a given path.

## Changes

![ADD] ![NEW] helper method `String readUnityVersion(File installation)`
![ADD] ![NEW] helper method `Installation atLocation(File)`

[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"