### PR TITLE
Improve Installation.atLocation

### DIFF
--- a/src/main/java/net/wooga/uvm/UnityVersionManager.java
+++ b/src/main/java/net/wooga/uvm/UnityVersionManager.java
@@ -121,7 +121,7 @@ public class UnityVersionManager {
     /**
      * Return the version as {@code String} of the unity installation at the provided location or {@code Null}.
      *
-     * @param installationLocation the path to the unity installation
+     * @param installationLocation the path to the unity installation or Unity executable
      * @return a version string or {@code null}
      */
     public static String readUnityVersion(File installationLocation) {

--- a/src/test/groovy/net/wooga/uvm/InstallationSpec.groovy
+++ b/src/test/groovy/net/wooga/uvm/InstallationSpec.groovy
@@ -97,6 +97,30 @@ class InstallationSpec extends Specification {
         version = "2017.1.0f1"
     }
 
+    @Unroll("can fetch installation with executable path")
+    def "get a installation from a exec path"() {
+        given:
+        def basedir = Files.createTempDirectory(buildDir.toPath(), "installationSpec_installation_at_location").toFile()
+        basedir.deleteOnExit()
+        def destination = new File(basedir, version)
+        assert !destination.exists()
+        def installation = UnityVersionManager.installUnityEditor(version, destination)
+        assert destination.exists()
+
+        expect:
+        def installation2 = Installation.atLocation(installation.executable)
+
+        installation2 != null
+        installation2 == installation
+        !installation2.is(installation)
+
+        cleanup:
+        destination.deleteDir()
+
+        where:
+        version = "2017.1.0f1"
+    }
+
     def "return null when installation at location doesn't exist"() {
         expect:
         !Installation.atLocation(File.createTempDir())


### PR DESCRIPTION
## Description

I made a mistake when implementing a fix https://github.com/wooga/atlas-unity/pull/52
The plugin tries to retrieve the version of Unity being executed to determine the arguments to pass for the `logFile` option. The fixed implementation is passing the path to the unity executable because the plugin isn't aware of a difference. So I decided to fix this issue in this library instead of the plugin.

I could or should push this logic in some form to the `uvm_core` library but won't do it at the moment. It is quite hard to find a nice looking implementation for this issue. The current solution works but is not very elegant.

The proposed implementation adjusts the installation path provided before passing it down to `uvm`. It checks if the path points to a file instead of a directory and returns a new path a few levels higher. This is a very brute force way of solving this issue for now and lacks error handling or transparency. In a worst case the resulting error from `uvm` could confuse users of this library when they pass a file pointing to a file and get reports of invalid unity location on a different path.

## Changes

![IMPROVE] `Installation.atLocation` fetch installations with executable path

[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"