### PR TITLE
Update build dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,9 @@ plugins {
     id 'groovy'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.8.4'
-    id 'nebula.release' version '6.3.5'
+    id 'nebula.release' version '10.1.2'
     id 'jacoco'
-    id 'com.github.kt3k.coveralls' version '2.8.2'
+    id 'com.github.kt3k.coveralls' version '2.8.4'
 }
 
 group "net.wooga"
@@ -48,8 +48,8 @@ repositories {
 dependencies {
     rustLib project('rust')
 
-    testCompile "org.codehaus.groovy:groovy-all:2.4.15"
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.4"
+    testCompile "org.codehaus.groovy:groovy-all:2.5.7"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
 }
 
 task collectLibs() {


### PR DESCRIPTION
## Description

This patch bundles all open patches from dependabot into one since some verson update can't be executed in an atomic fashion.

## Changes:

* ![UPDATE] [Bump com.github.kt3k.coveralls from 2.8.2 to 2.8.4 (#14)](https://github.com/wooga/unity-version-manager-jni/pull/14)
* ![UPDATE] [Bump groovy-all from 2.4.15 to 2.5.7 (#16)](https://github.com/wooga/unity-version-manager-jni/pull/16)
* ![UPDATE] [Bump spock-core from 1.2-groovy-2.4 to 1.3-groovy-2.5 (#18)](https://github.com/wooga/unity-version-manager-jni/pull/18)
* ![UPDATE] [Bump nebula.release from 6.3.5 to 10.1.2 (#19)](https://github.com/wooga/unity-version-manager-jni/pull/19)

[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"
