### PR TITLE
Bootstrap preinstalled Unity version in tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
       parallel {
         stage('osx') {
           agent {
-            label "osx && atlas && primary && unity && fast"
+            label "osx && atlas && primary && fast"
           }
 
           stages {

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
 
     testCompile "org.codehaus.groovy:groovy-all:2.4.15"
     testCompile "org.spockframework:spock-core:1.2-groovy-2.4"
+    testCompile "com.wooga.spock.extensions:spock-unity-version-manager-extension:0.1.0"
 }
 
 task collectLibs() {


### PR DESCRIPTION
## Description

Instead of using a unityversion being installed on the test system this patch ensures a unity installation at test runtime. It uses a spock extension library [spock-unity-version-manager-extension]. The irony is that this extension uses this library under the hood. Classic Henn and Egg problem. I don't see a huge issue with that.

## Changes

* ![IMPROVE] bootstrap preinstalled Unity versions in tests

[spock-unity-version-manager-extension]: https://github.com/wooga/spock-unity-version-manager-extension


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"