### PR TITLE
Update rust version

### DIFF
--- a/rust/build.gradle
+++ b/rust/build.gradle
@@ -25,7 +25,7 @@ rust {
         || System.getenv("IN_DOCKER") != null) {
         executable(searchPath())
     } else {
-        executable version : '1.37.0'
+        executable version : '1.42.0'
     }
 
     cargoToml './Cargo.toml'


### PR DESCRIPTION
## Description

Some dependencies won't build with `1.37.0` anymore. Windows was building with `1.42.0` the last couple of month. I forgot to bump macOS.

## Description

* ![UPDATE] rust version to `1.42.0`

[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"