### PR TITLE
Update rust toolchain to 1.50.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM openjdk:8-jdk
-
+ARG RUST_VERSION=1.50.0
+ARG UVM_VERSION=2.2.0
 
 RUN mkdir -p /home/ci
 
@@ -16,16 +17,15 @@ ENV IN_DOCKER="1"
 RUN apt-get update
 RUN apt-get install -y  build-essential libssl-dev pkg-config openssl p7zip-full cpio -y
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION
 ENV PATH="${HOME}/.cargo/bin:${PATH}"
 
 WORKDIR /home/ci/
 
-RUN curl -Lo unity-version-manager-2.2.0.tar.gz https://github.com/Larusso/unity-version-manager/archive/v2.2.0.tar.gz && \
-    tar -xzf unity-version-manager-2.2.0.tar.gz && \
-    cd unity-version-manager-2.2.0 && make install && \
-    uvm install 2019.1.0a7 /home/ci/.local/share/Unity-2019.1.0a7
+RUN curl -Lo "unity-version-manager-$UVM_VERSION.tar.gz" "https://github.com/Larusso/unity-version-manager/archive/v$UVM_VERSION.tar.gz"
+RUN tar -xzf "unity-version-manager-$UVM_VERSION.tar.gz"
+RUN cd "unity-version-manager-$UVM_VERSION" && make install
+RUN uvm install 2019.1.0a7 /home/ci/.local/share/Unity-2019.1.0a7
 
 # Chown all the files to the app user.
 RUN chown -R ci:ci $HOME

--- a/rust/build.gradle
+++ b/rust/build.gradle
@@ -25,7 +25,7 @@ rust {
         || System.getenv("IN_DOCKER") != null) {
         executable(searchPath())
     } else {
-        executable version : '1.42.0'
+        executable version : '1.50.0'
     }
 
     cargoToml './Cargo.toml'


### PR DESCRIPTION
## Description

I want to use the lasted rust toolchain to build this jni library. For this I adjusted the Dockerfile to use an argument for the default toolchain to install.

## Changes

* ![UPDATE] rust toolchain to `1.50.0`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"