### PR TITLE
Improve unity editor install with optional syncModules parameter

### DIFF
--- a/src/main/java/net/wooga/uvm/UnityVersionManager.java
+++ b/src/main/java/net/wooga/uvm/UnityVersionManager.java
@@ -119,6 +119,21 @@ public class UnityVersionManager {
      */
     public static native Installation installUnityEditor(String version, File destination, Component[] components);
 
+    /**
+     * Installs the given version of unity and additional components to destination.
+     *
+     * If the unity version and all requested components are already installed, returns early.
+     *
+     * @param version the version of unity to install
+     * @param destination the location to install unity to
+     * @param components a list of optional {@code Component}s to install
+     * @param syncModules installs all optional modules for selected components
+     *
+     * @return a {@code Installation} object or null
+     * @see Component
+     * @see Installation
+     */
+    public static native Installation installUnityEditor(String version, File destination, Component[] components, boolean syncModules);
 
     /**
      * Return the version as {@code String} of the unity installation at the provided location or {@code Null}.


### PR DESCRIPTION
## Description

Unity 2019.3 introduced new optional packages for the android component such as `android nkd` `android sdk` and `openJdk`. These where always autoinstalled by this library by default. This patch adds a new method variant with a boolean field to control this behavior. The boolean will be false by default to reduce install size.

## Changes

* ![IMPROVE] unity editor install with optional syncModules parameter