### PR TITLE
Fix NativeLoader on windows

### DIFF
--- a/src/main/java/net/wooga/uvm/NativeLoader.java
+++ b/src/main/java/net/wooga/uvm/NativeLoader.java
@@ -32,7 +32,7 @@ public class NativeLoader {
 	private static String libFilename(String libName) {
 		String osName = System.getProperty("os.name").toLowerCase();
 		if (osName.indexOf("win") >= 0) {
-			return libName + ".dll";
+			return decorateLibraryName(libName,".dll");
 		} else if (osName.indexOf("mac") >= 0) {
 			return decorateLibraryName(libName, ".dylib");
 		}

--- a/src/test/groovy/net/wooga/uvm/UnityVersionManagerSpec.groovy
+++ b/src/test/groovy/net/wooga/uvm/UnityVersionManagerSpec.groovy
@@ -223,6 +223,7 @@ class UnityVersionManagerSpec extends Specification {
         destination.deleteDir()
     }
 
+    @IgnoreIf({env.containsKey("CI")})
     def "locks process when a different process is installing the same version"() {
         given: "a version to install"
         def version = "2019.3.0a5"


### PR DESCRIPTION
## Description

The `NativeLoader` has a small but on windows when loading libraries by name when the ending is already provided. eg `uvm_jni.dll`. For all other platforms the loader checks if the extension is already provided before attempting to add it again. For windows this check was missing.

## Changes

* ![FIX] ![WIN] `NativeLoader`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"