### PR TITLE
Add snyk monitoring [ATLAS-677]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,9 @@ pipeline {
   environment {
     CI = true
     RUST_LOG = "warn,uvm_core=trace,uvm_move_dir=trace,uvm_install2=trace,uvm_jni=trace"
+    SNYK_TOKEN = credentials('snyk-wdk-token')
+    SNYK_AUTO_DOWNLOAD = "YES"
+    SNYK_ORG_NAME = "wooga-pipeline"
   }
 
   stages {
@@ -86,7 +89,7 @@ pipeline {
 
               post {
                 success {
-                  gradleWrapper "jacocoTestReport coveralls"
+                  gradleWrapper "jacocoTestReport"
                   publishHTML([
                     allowMissing: true,
                     alwaysLinkToLastBuild: true,
@@ -146,7 +149,7 @@ pipeline {
 
               post {
                 success {
-                  gradleWrapper "jacocoTestReport coveralls"
+                  gradleWrapper "jacocoTestReport"
                   publishHTML([
                     allowMissing: true,
                     alwaysLinkToLastBuild: true,

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,10 @@ plugins {
     id 'signing'
     id 'nebula.release' version '15.3.1'
     id 'jacoco'
-    id 'com.github.kt3k.coveralls' version '2.12.0'
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
+    id 'net.wooga.snyk' version '0.10.0'
+    id "net.wooga.snyk-wdk-java" version "0.3.0"
+    id "net.wooga.cve-dependency-resolution" version "0.4.0"
 }
 
 group "net.wooga"
@@ -42,16 +44,31 @@ configurations {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 
 dependencies {
     rustLib project('rust')
 
-    testCompile "org.codehaus.groovy:groovy-all:2.4.15"
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.4"
-    testCompile "com.wooga.spock.extensions:spock-unity-version-manager-extension:[0.1.0,1)"
+    testImplementation "org.codehaus.groovy:groovy-all:2.5.16"
+    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
+    testImplementation "com.wooga.spock.extensions:spock-unity-version-manager-extension:[0.1.0,1)"
+}
+
+cveHandler.configurations("compileClasspath", "testCompileClasspath", "testRuntimeClasspath")
+
+snyk {
+    projectTags = ["team": "atlas", "component": "library", "platform": "jvm", "language": "java"]
+    //TODO: add when snyk adds rust support
+//    registerProject(file("rust/Cargo.toml")) {
+//        projectTags.put("platform", "jni")
+//        projectTags.put("language", "rust")
+//        projectEnvironment = "internal"
+//    }
+//
+    registerProject(project.findProject(":rust")) {
+        projectEnvironment = "internal"
+    }
 }
 
 task collectLibs() {

--- a/rust/build.gradle
+++ b/rust/build.gradle
@@ -17,14 +17,14 @@
 
 plugins {
     id 'base'
-    id "net.wooga.rust.lib" version "0.1.0"
+    id "net.wooga.rust.lib" version "0.3.0-rc.1"
 }
 
 rust {
     useLocalInstallation(provider({
         System.getProperty("os.name").toLowerCase().contains("windows")
     }))
-    version.set("1.58.1")
+    version.set("1.59.0")
     patchCargoVersion(true)
 }
 


### PR DESCRIPTION
## Description

This patch adds snyk monitoring to the build pipeline. It will hook itself into the check and publish stages.

The patch also sets a dependency helper plugin `net.wooga.cve-dependency-resolution` which applies overrides for dependencies with know fixes for security issues.

Along with the introduction of snyk I also upgraded/removed some depdencies. Coveralls produces a huge load of errors even with the latest version so I decided to remove it since we want/are moving to sonarqube (It is unknown at this time if this dependency is actually better or not).

## Changes

* ![ADD] `snyk` monitoring
* ![ADD] `net.wooga.snyk-wdk-java` snyk convention plugin
* ![ADD] `net.wogoa.cve-dependency-resolution` plugin
* ![REMOVE] coveralls plugin
* ![UPDATE] `org.codehaus.groovy:groovy-all` to version `2.5.16`
* ![UPDATE] `org.spockframework:spock-core` to version `1.3-groovy-2.5`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"