### PR TITLE
Add aarch64 apple support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-
+import com.wooga.gradle.PlatformUtils
 plugins {
     id 'java-library'
     id 'groovy'
@@ -172,4 +172,18 @@ afterEvaluate {
     tasks.publishToSonatype.mustRunAfter(tasks.postRelease)
     tasks.closeSonatypeStagingRepository.mustRunAfter(tasks.publishToSonatype)
     tasks.publish.mustRunAfter(tasks.release)
+
+    println("check if running with rosseta2")
+    if(PlatformUtils.isMac()) {
+        def out = new ByteArrayOutputStream()
+        project.exec {
+            executable 'sysctl'
+            args '-n', '-i', 'sysctl.proc_translated'
+
+            //store the output instead of printing to the console:
+            standardOutput = out
+        }
+
+        println("runs on rosseta: ${out.toString().trim()}")
+    }
 }

--- a/rust/build.gradle
+++ b/rust/build.gradle
@@ -1,3 +1,7 @@
+import com.wooga.gradle.PlatformUtils
+import wooga.gradle.rust.tasks.AbstractRustCompile
+import wooga.gradle.rust.tasks.RustCompile
+
 /*
  * Copyright 2018 Wooga GmbH
  *
@@ -17,19 +21,71 @@
 
 plugins {
     id 'base'
-    id "net.wooga.rust.lib" version "0.3.0-rc.1"
+    id "net.wooga.rust.lib" version "0.4.2"
+    id "net.wooga.rustup" version "0.1.0"
+}
+
+def rustTargets = ["x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+rustup {
+    cargoHome.set(project.layout.buildDirectory.dir('cargo'))
+    rustupHome.set(project.layout.buildDirectory.dir('rustup'))
+
+    defaultToolchain = "stable"
+    update = true
+    profile = "minimal"
+
+    if (PlatformUtils.isMac()) {
+        targets = rustTargets.findAll { it.contains("apple") }
+    }
+    if (PlatformUtils.isLinux()) {
+        targets = rustTargets.findAll { it.contains("linux") }
+    }
+    if (PlatformUtils.isWindows()) {
+        targets = rustTargets.findAll { it.contains("windows") }
+    }
 }
 
 rust {
     useLocalInstallation(provider({
-        System.getProperty("os.name").toLowerCase().contains("windows")
+        true
     }))
-    version.set("1.59.0")
+
+    rustupHome(rustup.rustupHome)
+    cargoHome(rustup.cargoHome)
     patchCargoVersion(true)
 }
 
 compileLibRust {
+    dependsOn(rustup)
     release(true)
+}
+
+task compileMacOsAarch64(type: RustCompile) {
+    dependsOn(rustup)
+    compileType = AbstractRustCompile.CompileType.LIB
+    target = "aarch64-apple-darwin"
+    release(true)
+}
+
+task compileMacOsx86(type: RustCompile) {
+    dependsOn(rustup)
+    compileType = AbstractRustCompile.CompileType.LIB
+    target = "x86_64-apple-darwin"
+    release(true)
+}
+
+task generateUniversalBinary(type: Exec) {
+    inputs.files(
+            compileMacOsAarch64.getOutputDir().map({ it.file("libuvm_jni.dylib") }),
+            compileMacOsx86.getOutputDir().map({ it.file("libuvm_jni.dylib") }),
+    )
+
+    outputs.file("${buildDir}/output/libuvm_jni.dylib")
+
+    dependsOn compileMacOsAarch64, compileMacOsx86
+    executable = "lipo"
+    args "-create", "-output", outputs.files.singleFile
+    args inputs.files
 }
 
 configurations {
@@ -40,16 +96,27 @@ task copyOut(type: Copy) {
     dependsOn compileLibRust
 
     from file("${buildDir}/rust-project/target/release/")
-    include "*.dylib"
     include "*.dll"
     include "*.so"
     into file("${buildDir}/output")
 }
 
+task assembleLibraryFiles {
+    outputs.dir("${buildDir}/outputs")
+    if(PlatformUtils.isMac()) {
+        dependsOn generateUniversalBinary
+    } else {
+        dependsOn copyOut
+    }
+}
+
+
 configurations['default'].extendsFrom(configurations.rustLib)
 
 artifacts {
-    rustLib file: file("${buildDir}/output/libuvm_jni.dylib"), name: "libuvm_extern", type: "dylib", builtBy: copyOut
-    rustLib file: file("${buildDir}/output/libuvm_jni.so"), name: "libuvm_extern", type: "so", builtBy: copyOut
-    rustLib file: file("${buildDir}/output/uvm_jni.dll"), name: "libuvm_extern", type: "dll", builtBy: copyOut
+    rustLib file: file("${buildDir}/output/libuvm_jni.dylib"), name: "libuvm_extern", type: "dylib", builtBy: assembleLibraryFiles
+    rustLib file: file("${buildDir}/output/libuvm_jni.so"), name: "libuvm_extern", type: "so", builtBy: assembleLibraryFiles
+    rustLib file: file("${buildDir}/output/uvm_jni.dll"), name: "libuvm_extern", type: "dll", builtBy: assembleLibraryFiles
 }
+
+assemble.dependsOn assembleLibraryFiles


### PR DESCRIPTION
## Description

With the introduction of the AppleM1 and native java distributions it is needed to add support the `aarch64` target to the dylib. Apple supports the nothion of universal libries which contain multiple architectures. Rust does not support to build these kinds of libraries directly from cargo. But the basic steps to generate these universal libraries are simple.

1. build the lib in multiple architecture
2. call the `lipo` cli tool to generate a universal library from the provided lib.

In order to be able to crosscompile to both architectures we need the help of `rustup` to install the needed targets. The new plugin `net.wooga.rustup` takes care of this and we hook the installed cargo and toolchain into the `net.wooga.rust` plugin. I added some basic magic tasks that compile the lib twice and combine it to one library.

## Changes

* ![ADD] support for AppleM1 `aarch64`