### PR TITLE
Improve detect unity project version and install API

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -36,6 +36,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+
+[[package]]
 name = "argon2rs"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,36 +263,10 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
+ "strsim",
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "cli_core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ce2a4fed13508c92ba7afb5ad9a43b315614498d09366cc29c41d43108ab34"
-dependencies = [
- "console 0.6.2",
- "docopt",
- "flexi_logger 0.9.3",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "clicolors-control"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f84dec9bc083ce2503908cd305af98bd363da6f54bf8d4bf0ac14ee749ad5d1"
-dependencies = [
- "kernel32-sys",
- "lazy_static 0.2.11",
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -296,7 +276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
 dependencies = [
  "atty",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "winapi 0.3.9",
 ]
@@ -335,30 +315,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd48adf136733979b49e15bc3b4c43cc0d3c85ece7bd08e6daa414c6fcb13e6"
-dependencies = [
- "atty",
- "clicolors-control 0.2.0",
- "lazy_static 1.4.0",
- "libc",
- "parking_lot 0.12.0",
- "regex",
- "termios",
- "unicode-width",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "console"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e0f3986890b3acbc782009e2629dfe2baa430ac091519ce3be26164a2ae6c0"
 dependencies = [
- "clicolors-control 1.0.1",
+ "clicolors-control",
  "encode_unicode",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "regex",
  "termios",
@@ -460,7 +423,7 @@ dependencies = [
  "autocfg 1.1.0",
  "cfg-if 0.1.10",
  "crossbeam-utils",
- "lazy_static 1.4.0",
+ "lazy_static",
  "maybe-uninit",
  "memoffset",
  "scopeguard",
@@ -485,7 +448,7 @@ checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg 1.1.0",
  "cfg-if 0.1.10",
- "lazy_static 1.4.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -536,18 +499,6 @@ checksum = "7e565b39e64e4030c75320536cc18cd51f0636811c53d98a05f01ec5deb8dd8f"
 dependencies = [
  "log 0.3.9",
  "plist 0.2.4",
-]
-
-[[package]]
-name = "docopt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3f119846c823f9eafcf953a8f6ffb6ed69bf6240883261a7f13b634579a51f"
-dependencies = [
- "lazy_static 1.4.0",
- "regex",
- "serde",
- "strsim 0.10.0",
 ]
 
 [[package]]
@@ -638,26 +589,14 @@ dependencies = [
 
 [[package]]
 name = "flexi_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7992096ba2290bd35b86b282e72edae518a25aa9a067ff417bc017ae63ac5e22"
-dependencies = [
- "chrono",
- "glob 0.2.11",
- "log 0.4.14",
- "regex",
-]
-
-[[package]]
-name = "flexi_logger"
 version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaab3caedb4149800f91e8e4899f29cd9ddf3b569b04c365ca9334f92f7542bf"
 dependencies = [
  "atty",
  "chrono",
- "glob 0.3.0",
- "lazy_static 1.4.0",
+ "glob",
+ "lazy_static",
  "log 0.4.14",
  "regex",
  "thiserror",
@@ -672,8 +611,8 @@ checksum = "33ab94b6ac8eb69f1496a6993f26f785b5fd6d99b7416023eb2a6175c0b242b1"
 dependencies = [
  "atty",
  "chrono",
- "glob 0.3.0",
- "lazy_static 1.4.0",
+ "glob",
+ "lazy_static",
  "log 0.4.14",
  "regex",
  "thiserror",
@@ -763,12 +702,6 @@ name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
-
-[[package]]
-name = "glob"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 
 [[package]]
 name = "glob"
@@ -960,7 +893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
 dependencies = [
  "console 0.15.0",
- "lazy_static 1.4.0",
+ "lazy_static",
  "number_prefix",
  "regex",
 ]
@@ -988,6 +921,15 @@ name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -1036,12 +978,6 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-
-[[package]]
-name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -1063,15 +999,6 @@ name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -1195,7 +1122,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "log 0.4.14",
  "openssl",
@@ -1319,19 +1246,9 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.6.2",
+ "lock_api",
+ "parking_lot_core",
  "rustc_version",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
-dependencies = [
- "lock_api 0.4.6",
- "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -1345,21 +1262,8 @@ dependencies = [
  "libc",
  "redox_syscall 0.1.57",
  "rustc_version",
- "smallvec 0.6.14",
+ "smallvec",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "redox_syscall 0.2.10",
- "smallvec 1.8.0",
- "windows-sys",
 ]
 
 [[package]]
@@ -1741,7 +1645,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "winapi 0.3.9",
 ]
 
@@ -1883,12 +1787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
-
-[[package]]
 name = "string"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,19 +1802,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
- "lazy_static 1.4.0",
+ "lazy_static",
  "structopt-derive",
 ]
 
@@ -2000,18 +1892,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2113,11 +2005,11 @@ checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
  "crossbeam-utils",
  "futures",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log 0.4.14",
  "mio",
  "num_cpus",
- "parking_lot 0.9.0",
+ "parking_lot",
  "slab",
  "tokio-executor",
  "tokio-io",
@@ -2158,7 +2050,7 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-utils",
  "futures",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log 0.4.14",
  "num_cpus",
  "slab",
@@ -2283,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "uvm-install2"
-version = "0.5.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46b77e55b273875e5aa331509ca89d894e40523b2a02cafc27ae1d069b30249c"
+checksum = "2385c752a39dd61d6a06172e4e28e60b7e169452155309f6cb43085d52813026"
 dependencies = [
  "console 0.9.2",
  "dirs-2",
@@ -2303,27 +2195,26 @@ dependencies = [
 
 [[package]]
 name = "uvm_cli"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8631beea5751a944a220156937c8413d0bc6169c2d658b5d88211f2343307b4"
+checksum = "4a6e3e43aa667bcc3da20260c113919342d4849766dca3394cc60f1294af601a"
 dependencies = [
- "cli_core",
  "console 0.9.2",
- "docopt",
  "flexi_logger 0.17.1",
+ "itertools 0.10.5",
  "log 0.4.14",
  "serde",
  "serde_derive",
  "structopt",
- "uvm_core",
 ]
 
 [[package]]
 name = "uvm_core"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd01ce9932355574a79e966ab9a9a6a279c9aae1e26c6106b72ab9cacebf4353"
+checksum = "7fd55b13bee72f6500fa0a073516f218e92c40f97fd1f9d4779bd84134646c97"
 dependencies = [
+ "anyhow",
  "cfg-if 1.0.0",
  "cluFlock",
  "derive_deref",
@@ -2332,8 +2223,8 @@ dependencies = [
  "error-chain",
  "hex 0.4.3",
  "hex-serde",
- "itertools",
- "lazy_static 1.4.0",
+ "itertools 0.9.0",
+ "lazy_static",
  "libc",
  "log 0.4.14",
  "md-5",
@@ -2347,6 +2238,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
+ "thiserror",
  "widestring",
  "winapi 0.3.9",
  "zip",
@@ -2354,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "uvm_install_core"
-version = "0.5.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "672ef52500ee1bb7b569d4e92eafc74527b2e0f305a46895b8f0683402a4d615"
+checksum = "d5546882dff16f175fb415982182c5dc3f9f87f96aacfb956bcd1073ad7f7828"
 dependencies = [
  "cfg-if 1.0.0",
  "derive_deref",
@@ -2375,13 +2267,13 @@ dependencies = [
 
 [[package]]
 name = "uvm_install_graph"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd573c7916235ed71a33d335d6e2ea272fb91eb4c3f68b7d18c36f6f05d81597"
+checksum = "c20e14b75130ce590dc9842290dcdc0e3ac690b7c38cb22f473d26cdf6b3b71d"
 dependencies = [
  "daggy",
  "fixedbitset",
- "itertools",
+ "itertools 0.9.0",
  "uvm_core",
 ]
 
@@ -2389,10 +2281,10 @@ dependencies = [
 name = "uvm_jni"
 version = "0.2.0"
 dependencies = [
- "error-chain",
  "flexi_logger 0.15.12",
  "jni",
  "log 0.4.14",
+ "thiserror",
  "uvm-install2",
 ]
 
@@ -2508,49 +2400,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
-dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "winreg"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 
 [dependencies]
 jni = "0.15.0"
-uvm-install2 = "0.5.0"
-error-chain = "0.12.2"
+uvm-install2 = "0.8.0"
 log = "0.4.8"
 flexi_logger = "0.15.1"
+thiserror = "1.0.37"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/main/java/net/wooga/uvm/UnityVersionManager.java
+++ b/src/main/java/net/wooga/uvm/UnityVersionManager.java
@@ -49,7 +49,27 @@ public class UnityVersionManager {
      * @param projectPath the path to the unity project root
      * @return a version string or {@code NULL}
      */
-    public static native String detectProjectVersion(File projectPath);
+    public static String detectProjectVersion(File projectPath) {
+        return detectProjectVersion(projectPath, false);
+    }
+
+    /**
+     * Detects the unity editor version used in {@code projectPath}.
+     * <p>
+     * The second {@code Boolean} parameter {@code withRevision} controls the format of the version string.
+     * When set to {@code true} the returned version will be based on the <b>m_EditorVersionWithRevision</b> parameter
+     * in the <b>ProjectVersion.txt</b> file. e.g. <i>2020.3.38f1 (8f5fde82e2dc)</i>
+     * <p>
+     * Note:
+     * If the project is saved in an older format without the <b>m_EditorVersionWithRevision</b> parameter, then the
+     * <b>m_EditorVersion</b> parameter will be used which contains only the base version. Even if the <b>m_EditorVersion</b>
+     * is used the version could be returned with a release hash. But only if the version is known to uvm.
+     *
+     * @param projectPath the path to the unity project root
+     * @param withRevisionHash return the version with the release revision hash
+     * @return a version string or {@code NULL}
+     */
+    public static native String detectProjectVersion(File projectPath, boolean withRevisionHash);
 
     /**
      * Returns the path to the installation location for the provided version or {@code Null}.


### PR DESCRIPTION
## Description

The latest updated to `uvm-install2` crate brought the ability to fetch the revision hash from the `ProjectVersion.txt` file. This means that even if the webservice, which provides the mapping from unity version string to version revision hash, is outdated or doesn't know the *maybe* valid version requested it is still able to download all installer resources. This can become crucial for custom internal beta releases from Untiy which are not tracked in the offical release files and pages.

This change consists of a small API change in `UnityVersionManager` and a verification test change in the tests to verify that it is possible to request a unity editor installation with a version containing a revision hash.

> Note:
> Unity version is a complicated mess. In praxis most humans express the version in the form of
> `2020.3.20f1`. But sadly that is not enough to install a unity version. All installation resources
> need a second information which is the *revision* (term is not quite clear to me but that is the latest term
> I saw in the new graphQL endpoint). Together with the version and the revision on can find the installer
> manifest which includes all the informations where installers are located etc.
> UVM stores unity versions not as a string object like we do in java land. For one the version needs to be
> able to be sorted etc. And the revision hash is treated as an optional part which can be requested. If the version
> doesn't know the revision it will try to locate it from the versions service or local cache.
> This is the key here as the latest patches allowed to parse a version from a string with the revision included!

The mentioned patch in `UnityVersionManager` updates the API for `detectProjectVersion` method. I added a new parameter `detectProjectVersion(File, boolean)`. I also added a backwards compatible API which will call the method with the second paramter set to `false` which results in the old behavior.

With the new second parameter set to `true`, the underlying library will return the unity version printed in the form of `2020.3.20f1 (REVSION)`. This version can be directly used to request the installation. The process is transparent. I decided to add/update the API rather than just changeing the return value because I want to be able to control what format the version will be returned in. In the future I think it would be better to create a custom version object which maps better to the one in rust. This would also allow to sort and compare versions.

## Changes

* ![IMPROVE] unity project version detection API

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"