### PR TITLE
Adds listAvailableComponents method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,26 @@
+FROM openjdk:8-jdk-buster
 ARG RUST_VERSION=1.50.0
-
-FROM rust:$RUST_VERSION-buster
 ARG UVM_VERSION=2.2.0
+
+# Create an app user so our program doesn't run as root.
+# Set the home directory to our app user's home.
 
 ENV RUST_BACKTRACE=1
 ENV RUST_LOG="warning, uvm_core=trace, uvm_jni=trace"
 ENV IN_DOCKER="1"
 
+RUN apt-get update
+RUN apt-get install -y make build-essential libssl-dev pkg-config openssl p7zip-full cpio
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION
+ENV PATH="${HOME}/.cargo/bin:${PATH}"
 RUN curl -Lo "unity-version-manager-$UVM_VERSION.tar.gz" "https://github.com/Larusso/unity-version-manager/archive/v$UVM_VERSION.tar.gz"
-RUN tar -xzf "unity-version-manager-$UVM_VERSION.tar.gz" && rm "unity-version-manager-$UVM_VERSION.tar.gz"
-
-RUN cd "unity-version-manager-$UVM_VERSION" && PATH="${HOME}/.cargo/bin:$PATH" make install
-
-#AdoptOpenJDK was deprecated on favor of Temurin
-RUN apt-get update && apt-get install -y wget apt-transport-https gnupg
-RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
-RUN echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
-RUN apt-get update && apt-get -y install temurin-8-jdk
+RUN tar -xzf "unity-version-manager-$UVM_VERSION.tar.gz" && rm -f "unity-version-manager-$UVM_VERSION.tar.gz"
+RUN cd "unity-version-manager-$UVM_VERSION" && PATH="${HOME}/.cargo/bin:${PATH}" make install
 
 ARG USER_ID=1001
 ARG GROUP_ID=100
-
 RUN useradd -u ${USER_ID} -g ${GROUP_ID} --create-home ci
 
 USER ci
-#COPY --from=0 /usr/local/bin/uvm* ./usr/local/bin/
-
 RUN uvm install 2019.1.0a7 /home/ci/.local/share/Unity-2019.1.0a7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,29 @@
-FROM openjdk:8-jdk-stretch
 ARG RUST_VERSION=1.50.0
+
+FROM rust:$RUST_VERSION-buster
 ARG UVM_VERSION=2.2.0
 
-RUN mkdir -p /home/ci
-
-# Create an app user so our program doesn't run as root.
-RUN groupadd -r ci &&\
-    useradd -r -g ci -d /home/ci -s /sbin/nologin -c "Docker image user" ci
-
-# Set the home directory to our app user's home.
-ENV HOME=/home/ci
-ENV GRADLE_USER_HOME=$HOME/.gradle
-ENV _JAVA_OPTIONS="-Duser.home=$HOME"
 ENV RUST_BACKTRACE=1
 ENV RUST_LOG="warning, uvm_core=trace, uvm_jni=trace"
 ENV IN_DOCKER="1"
 
-RUN apt-get update
-RUN apt-get install -y  build-essential libssl-dev pkg-config openssl p7zip-full cpio -y
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION
-ENV PATH="${HOME}/.cargo/bin:${PATH}"
-
-WORKDIR /home/ci/
-
 RUN curl -Lo "unity-version-manager-$UVM_VERSION.tar.gz" "https://github.com/Larusso/unity-version-manager/archive/v$UVM_VERSION.tar.gz"
-RUN tar -xzf "unity-version-manager-$UVM_VERSION.tar.gz"
-RUN cd "unity-version-manager-$UVM_VERSION" && make install
-RUN uvm install 2019.1.0a7 /home/ci/.local/share/Unity-2019.1.0a7
+RUN tar -xzf "unity-version-manager-$UVM_VERSION.tar.gz" && rm "unity-version-manager-$UVM_VERSION.tar.gz"
 
-# Chown all the files to the app user.
-RUN chown -R ci:ci $HOME
-RUN chmod -R 777 $HOME
+RUN cd "unity-version-manager-$UVM_VERSION" && PATH="${HOME}/.cargo/bin:$PATH" make install
+
+#AdoptOpenJDK was deprecated on favor of Temurin
+RUN apt-get update && apt-get install -y wget apt-transport-https gnupg
+RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
+RUN echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
+RUN apt-get update && apt-get -y install temurin-8-jdk
+
+ARG USER_ID=1001
+ARG GROUP_ID=100
+
+RUN useradd -u ${USER_ID} -g ${GROUP_ID} --create-home ci
+
+USER ci
+#COPY --from=0 /usr/local/bin/uvm* ./usr/local/bin/
+
+RUN uvm install 2019.1.0a7 /home/ci/.local/share/Unity-2019.1.0a7

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ plugins {
 }
 
 group "net.wooga"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+java.targetCompatibility = JavaVersion.VERSION_1_8
+
 
 List<String> cliTasks = project.rootProject.gradle.startParameter.taskNames
 if (cliTasks.contains("rc")) {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2286,6 +2286,7 @@ dependencies = [
  "log 0.4.14",
  "thiserror",
  "uvm-install2",
+ "uvm_core",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 jni = "0.15.0"
 uvm-install2 = "0.9.0"
+uvm_core = "0.13.0"
 log = "0.4.8"
 flexi_logger = "0.15.1"
 thiserror = "1.0.37"

--- a/src/main/java/net/wooga/uvm/UnityVersionManager.java
+++ b/src/main/java/net/wooga/uvm/UnityVersionManager.java
@@ -127,6 +127,12 @@ public class UnityVersionManager {
      */
     public static native Installation installUnityEditor(String version, File destination, Component[] components);
 
+    /**
+     * List all available components for the given unity version in the current platform.
+     * @param version the version of unity to list components from
+     * @return a {@code Components[]} containing the requested components
+     */
+    public static native Component[] listAvailableComponents(String version);
 
     /**
      * Return the version as {@code String} of the unity installation at the provided location or {@code Null}.

--- a/src/test/groovy/net/wooga/uvm/UnityVersionManagerSpec.groovy
+++ b/src/test/groovy/net/wooga/uvm/UnityVersionManagerSpec.groovy
@@ -314,4 +314,16 @@ class UnityVersionManagerSpec extends Specification {
         then:
         result == installation.version
     }
+
+    @Unroll
+    def "return unity #version components for current platform"() {
+        expect:
+        def components = UnityVersionManager.listAvailableComponents(version)
+        components != null
+        components.size() > 0
+
+        where:
+        version << ["2019.4.31f1", "2019.4.1f1", "2020.1.1f1", "2021.1.1f1", "2022.1.1f1"]
+
+    }
 }


### PR DESCRIPTION
## Description

Adds new method to `UnityVersionManager`, `listAvailableComponents`. It list all available components for a given unity version in the current OS. 
Also put some minor refactors, as updating the UVM Dockerfile, and adding 1.8 as the explicit project java version.

## Changes
![ADD] `listAvailableComponents` method