### PR TITLE
Downgrade dockerfile debian back to stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-#Using older version of debian (stretch) to use older, and thus with wider compatibility range glibc
+#Using older version of debian (stretch) to use older glibc, and thus with wider compatibility range.
 FROM openjdk:8-jdk-stretch
 ARG RUST_VERSION=1.50.0
 ARG UVM_VERSION=2.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:8-jdk-buster
+#Using older version of debian (stretch) to use older, and thus with wider compatibility range glibc
+FROM openjdk:8-jdk-stretch
 ARG RUST_VERSION=1.50.0
 ARG UVM_VERSION=2.2.0
 


### PR DESCRIPTION
## Description

`glibc` is backwards-compatible, but not forwards-compatible. Thus we want to build with a old version of `glibc` to ensure a bigger compatibility range (which includes Ubuntu 18/Debian 9 and onwards).
Previous Dockerfiles in this project were using debian stretch. However the latest rc was built using debian buster, and this raises compatibility issues. So, we change the Dockerfile debian version back to the older one, stretch.
