### PR TITLE
Update rust dependency uvm-install2 to version 0.9.1

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2352,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "uvm-install2"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff3d92fed36c2407c69ff478babfcafdaac02c31ec57a0c7e7ac39f3be682a2"
+checksum = "72377c33d7a17cae4344e164c76b832af67e0aedec07fbad66e310f2b5c907e3"
 dependencies = [
  "console 0.9.2",
  "dirs-2",
@@ -2387,9 +2387,9 @@ dependencies = [
 
 [[package]]
 name = "uvm_core"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4073d87d19d385c8804ffc27aa373d5e98b7d0e1427512637d74ab8d59ae0357"
+checksum = "1ca73303c19482788bed772f8d0b1a65f4ee6f0d35ea9f5023a292b732756d70"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -2423,9 +2423,9 @@ dependencies = [
 
 [[package]]
 name = "uvm_install_core"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e623bcf59b12ce1c74b6212339af4e964fba184a98633b8a23e80c6db1c433b"
+checksum = "dc91f91f6fe55dc393e31d308156702d5797af58d7d16c0b7e19486f833d1581"
 dependencies = [
  "cfg-if 1.0.0",
  "derive_deref",
@@ -2444,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "uvm_install_graph"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4d00b3f2bdd17b53dd42677a5355d04f4e59f8f8831212ecee8b6089363e1c"
+checksum = "7977289caa15f8f5fa5efab8a6cbfba972abbc5221345e34edbc5f26161b35dc"
 dependencies = [
  "daggy",
  "fixedbitset",
@@ -2456,7 +2456,7 @@ dependencies = [
 
 [[package]]
 name = "uvm_jni"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "flexi_logger 0.15.12",
  "jni",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "uvm_jni"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 edition = "2018"
 
 [dependencies]
 jni = "0.15.0"
-uvm-install2 = "0.9.0"
-uvm_core = "0.13.1"
+uvm-install2 = "0.9.1"
+uvm_core = "0.13.2"
 log = "0.4.8"
 flexi_logger = "0.15.1"
 thiserror = "1.0.37"


### PR DESCRIPTION
## Description

The latest version of `uvm-install2` `0.9.1` adds a fix for the default installation version of the JDK component. In Unity 2022.2 it changed from JDK8 to JDK11 and is still a hardcoded value inside the library.

## Changes

* ![UPDATE] `uvm-install2` to version `0.9.1`