### PR TITLE
Update uvm_install2 to version 0.9.2 [ATLAS-1581]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV RUST_BACKTRACE=1
 ENV RUST_LOG="warning, uvm_core=trace, uvm_jni=trace"
 ENV IN_DOCKER="1"
 
+RUN echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get install -y make build-essential libssl-dev pkg-config openssl p7zip-full cpio
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2352,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "uvm-install2"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72377c33d7a17cae4344e164c76b832af67e0aedec07fbad66e310f2b5c907e3"
+checksum = "c05e5097589b7f76bbfafc7e603e3af7f0f4c5302259e7750958415321248b0e"
 dependencies = [
  "console 0.9.2",
  "dirs-2",
@@ -2423,9 +2423,9 @@ dependencies = [
 
 [[package]]
 name = "uvm_install_core"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc91f91f6fe55dc393e31d308156702d5797af58d7d16c0b7e19486f833d1581"
+checksum = "88565a0b58c6e29ad5c98877eb1ae8e6d6623680d90d705686d9b1d57fa974b7"
 dependencies = [
  "cfg-if 1.0.0",
  "derive_deref",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 jni = "0.15.0"
-uvm-install2 = "0.9.1"
+uvm-install2 = "0.9.2"
 uvm_core = "0.13.2"
 log = "0.4.8"
 flexi_logger = "0.15.1"


### PR DESCRIPTION
## Description

The latest patch release of `uvm_install2` contains a fix for linux which errors when installing android modules for version `2022.3.10f1`

## Changes

* ![UPDATE] `uvm_install2` to version `0.9.2`