### PR TITLE
Add additional flag to opt out of sync module installation

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -370,6 +370,7 @@ fn install_unity_editor(
     version: JString,
     destination: Option<JObject>,
     components: Option<jobjectArray>,
+    sync: Option<jboolean>,
 ) -> error::UvmJniResult<jobject> {
     let version = env.get_string(version)?;
     let version: String = version.into();
@@ -396,7 +397,12 @@ fn install_unity_editor(
         None
     };
 
-    let installation = uvm_install2::install(&version, variants, true, destination.as_ref())?;
+    let sync_components = match sync {
+        Some(v) => v == 1,
+        None => true,
+    };
+
+    let installation = uvm_install2::install(&version, variants, sync_components, destination.as_ref())?;
     let native_installation = jni_utils::get_installation(&env, &installation)?;
     Ok(native_installation.into_inner())
 }
@@ -410,7 +416,7 @@ pub extern "system" fn Java_net_wooga_uvm_UnityVersionManager_installUnityEditor
     destination: JObject,
 ) -> jobject {
     start_logger();
-    install_unity_editor(&env, version, Some(destination), None)
+    install_unity_editor(&env, version, Some(destination), None, None)
         .unwrap_or_else(jni_utils::print_error_and_return_null)
 }
 
@@ -422,34 +428,36 @@ pub extern "system" fn Java_net_wooga_uvm_UnityVersionManager_installUnityEditor
     version: JString,
 ) -> jobject {
     start_logger();
-    install_unity_editor(&env, version, None, None)
+    install_unity_editor(&env, version, None, None, None)
         .unwrap_or_else(jni_utils::print_error_and_return_null)
 }
 
 #[no_mangle]
 #[allow(non_snake_case)]
-pub extern "system" fn Java_net_wooga_uvm_UnityVersionManager_installUnityEditor__Ljava_lang_String_2_3Lnet_wooga_uvm_Component_2(
+pub extern "system" fn Java_net_wooga_uvm_UnityVersionManager_installUnityEditor__Ljava_lang_String_2_3Lnet_wooga_uvm_Component_2Z(
     env: JNIEnv,
     _class: JClass,
     version: JString,
     components: jobjectArray,
+    sync_components: jboolean
 ) -> jobject {
     start_logger();
-    install_unity_editor(&env, version, None, Some(components))
+    install_unity_editor(&env, version, None, Some(components), Some(sync_components))
         .unwrap_or_else(jni_utils::print_error_and_return_null)
 }
 
 #[no_mangle]
 #[allow(non_snake_case)]
-pub extern "system" fn Java_net_wooga_uvm_UnityVersionManager_installUnityEditor__Ljava_lang_String_2Ljava_io_File_2_3Lnet_wooga_uvm_Component_2(
+pub extern "system" fn Java_net_wooga_uvm_UnityVersionManager_installUnityEditor__Ljava_lang_String_2Ljava_io_File_2_3Lnet_wooga_uvm_Component_2Z(
     env: JNIEnv,
     _class: JClass,
     version: JString,
     destination: JObject,
     components: jobjectArray,
+    sync_components: jboolean
 ) -> jobject {
     start_logger();
-    install_unity_editor(&env, version, Some(destination), Some(components))
+    install_unity_editor(&env, version, Some(destination), Some(components), Some(sync_components))
         .unwrap_or_else(jni_utils::print_error_and_return_null)
 }
 

--- a/src/main/java/net/wooga/uvm/UnityVersionManager.java
+++ b/src/main/java/net/wooga/uvm/UnityVersionManager.java
@@ -111,7 +111,23 @@ public class UnityVersionManager {
      * @see Component
      * @see Installation
      */
-    public static native Installation installUnityEditor(String version, Component[] components);
+    public static Installation installUnityEditor(String version, Component[] components) {
+        return installUnityEditor(version, components, true);
+    }
+
+    /**
+     * Installs the given version of unity and additional components to default destination.
+     * <p>
+     * If the unity version and all requested components are already installed, returns early.
+     *
+     * @param version    the version of unity to install
+     * @param components a list of optional {@code Component}s to install
+     * @param syncChildComponents should child components automatically be installed (e.g. Andoid SDK/NDK)
+     * @return a {@code Installation} object or null
+     * @see Component
+     * @see Installation
+     */
+    public static native Installation installUnityEditor(String version, Component[] components, boolean syncChildComponents);
 
     /**
      * Installs the given version of unity and additional components to destination.
@@ -125,7 +141,24 @@ public class UnityVersionManager {
      * @see Component
      * @see Installation
      */
-    public static native Installation installUnityEditor(String version, File destination, Component[] components);
+    public static Installation installUnityEditor(String version, File destination, Component[] components) {
+        return installUnityEditor(version, destination, components, true);
+    }
+
+    /**
+     * Installs the given version of unity and additional components to destination.
+     * <p>
+     * If the unity version and all requested components are already installed, returns early.
+     *
+     * @param version     the version of unity to install
+     * @param destination the location to install unity to
+     * @param components  a list of optional {@code Component}s to install
+     * @param syncChildComponents should child components automatically be installed (e.g. Andoid SDK/NDK)
+     * @return a {@code Installation} object or null
+     * @see Component
+     * @see Installation
+     */
+    public static native Installation installUnityEditor(String version, File destination, Component[] components, boolean syncChildComponents);
 
     /**
      * List all available components for the given unity version in the current platform.


### PR DESCRIPTION
## Description

This patch adds a API addition which is fully backwards compatible both in API and behavior. I added a new `installUnityEditor` overload which adds a new property `syncChildComponents`. I used the naming scheme from uvm. So it's component instead of modules. The current default behavior is to install all sub modules of a given module. e.g. Android will also install android NDK, SDK etc.

We want to opt out of this. For this library I would like to keep the old behavior and fix it on the calling side.

## Changes

* ![ADD] boolean flag to opt out of sync module installation